### PR TITLE
Accept file list as argument

### DIFF
--- a/octavvs/preprocessing.py
+++ b/octavvs/preprocessing.py
@@ -239,6 +239,10 @@ class MyMainWindow(QMainWindow, Ui_MainWindow):
 
         exceptiondialog.install(self)
 
+        argsFileList = sys.argv[1:]
+        if argsFileList != [] :
+            self.updateFileList(argsFileList,False) #Loads files passed as arguments
+
     def showDetailedErrorMessage(self, err, details):
         "Show an error dialog with details"
         q = QMessageBox(self)


### PR DESCRIPTION
Automatically loads any file(s) passed as an argument.
Ex. : `python run_preprocessing.py ~/test.mat ~/test1.mat` will open octavvs with test.mat and test1.mat already loaded.